### PR TITLE
Some updates

### DIFF
--- a/cluster/cluster.stack.yml
+++ b/cluster/cluster.stack.yml
@@ -40,7 +40,7 @@ Resources:
   Cluster:
     Type: "AWS::EKS::Cluster"
     Properties:
-      Version: "1.10"
+      Version: "1.14"
       RoleArn: !GetAtt ClusterRole.Arn
       ResourcesVpcConfig:
         SecurityGroupIds:

--- a/nodes/nodes.stack.yml
+++ b/nodes/nodes.stack.yml
@@ -19,7 +19,7 @@ Parameters:
   NodeImageId:
     Type: AWS::EC2::Image::Id
     Description: AMI id for the node instances.
-    Default: ami-dea4d5a1
+    Default: ami-0812df1ae4450c89a
 
   NodeInstanceType:
     Description: EC2 instance type for the node instances
@@ -303,7 +303,7 @@ Resources:
       ToPort: 443
       FromPort: 443
 
-  NodeGroup:
+  AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       DesiredCapacity: !Ref NodeAutoScalingGroupMaxSize
@@ -326,6 +326,51 @@ Resources:
       AutoScalingRollingUpdate:
         MinInstancesInService: '1'
         MaxBatchSize: '1'
+
+  NodeGroup:
+    Type: AWS::EKS::Nodegroup
+    Properties:
+      AmiType: "AL2_x86_64"    # Append _GPU if you want GPU
+      ClusterName: !Ref ClusterName
+      DiskSize: 100            # 100 GiB
+      ForceUpdateEnabled: false
+      InstanceTypes:
+        - "t3.2xlarge"
+      Labels: {}
+      NodegroupName: !Ref NodeGroupName
+      NodeRole: !GetAtt NodeInstanceRole.Arn
+      RemoteAccess:
+        Ec2SshKey: !Ref KeyName
+        SourceSecurityGroups:
+          - !Ref NodeSecurityGroup
+      ScalingConfig:
+        DesiredSize: 2
+        MaxSize: 12
+        MinSize: 2
+      Subnets:
+        - Fn::ImportValue:
+            !Sub "${VPCStack}-PublicSubnet1ID"
+        - Fn::ImportValue:
+            !Sub "${VPCStack}-PublicSubnet2ID"
+
+  ClusterAutoScalerPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: ClusterAutoScalerPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - "autoscaling:DescribeAutoScalingGroups"
+              - "autoscaling:DescribeAutoScalingInstances"
+              - "autoscaling:DescribeLaunchConfigurations"
+              - "autoscaling:DescribeTags"
+              - "autoscaling:SetDesiredCapacity"
+              - "autoscaling:TerminateInstanceInAutoScalingGroup"
+            Resource: '*'
+      Roles:
+        - !Ref NodeInstanceRole
 
   NodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration

--- a/nodes/nodes.stack.yml
+++ b/nodes/nodes.stack.yml
@@ -335,7 +335,7 @@ Resources:
       DiskSize: 100            # 100 GiB
       ForceUpdateEnabled: false
       InstanceTypes:
-        - "t3.2xlarge"
+        - !Ref NodeInstanceType
       Labels: {}
       NodegroupName: !Ref NodeGroupName
       NodeRole: !GetAtt NodeInstanceRole.Arn
@@ -344,9 +344,9 @@ Resources:
         SourceSecurityGroups:
           - !Ref NodeSecurityGroup
       ScalingConfig:
-        DesiredSize: 2
-        MaxSize: 12
-        MinSize: 2
+        DesiredSize: !Ref NodeAutoScalingGroupMinSize
+        MaxSize: !Ref NodeAutoScalingGroupMaxSize
+        MinSize: !Ref NodeAutoScalingGroupMinSize
       Subnets:
         - Fn::ImportValue:
             !Sub "${VPCStack}-PublicSubnet1ID"


### PR DESCRIPTION
* Updated to kubernetes 1.14. This seems to be the only version that supports adding nodegroup in EKS.
* Changed AMI ID to the Ubuntu 18.04 AMI ID
* Added Nodegroup. This will automatically make the added VM nodes visible to kubectl. So the last bit about applying aws-auth-cm.yaml is no longer required.
* Also added policy for autoscaler and mentioned the instructions in readme. This is optional.